### PR TITLE
dashArraySizeOne on addSlice and SCATTERED_COLORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ I built build a better one in a few hours.
 
 ---
 
+## Version 1.3.2 Notes:
+
+- Changing colors of fraction slices to make each slice stand out more against adjacent slices
+- Changing `addSlice`'s `stroke-dasharray` from `calc` for Firefox compatibility
+
+---
+
 ## Version 1.3.1 Notes:
 
 - Restructuring codebase

--- a/scripts/DOM/circleSVG.js
+++ b/scripts/DOM/circleSVG.js
@@ -196,9 +196,10 @@ export const addSlice = (
 
   newSlice.setAttribute("stroke", color);
   newSlice.setAttribute("stroke-width", "50");
+	const dashArraySizeOne = percentSize * 157.08 / 100;
   newSlice.setAttribute(
     "stroke-dasharray",
-    `calc(${percentSize} * 157.08 / 100) 157.08`
+    `${dashArraySizeOne} 157.08`
   );
   newSlice.setAttribute("transform-origin", "center");
   let transform = `rotate(${startingAngle})`;

--- a/scripts/data/constants.js
+++ b/scripts/data/constants.js
@@ -17,6 +17,19 @@ export const RAINBOW_COLORS = [
   "#4B0082",
 ];
 
+export const SCATTERED_COLORS = [
+	RAINBOW_COLORS[0],
+	RAINBOW_COLORS[7],
+	RAINBOW_COLORS[4],
+	RAINBOW_COLORS[8],
+	RAINBOW_COLORS[3],
+	RAINBOW_COLORS[6],
+	"magenta",
+	RAINBOW_COLORS[5],
+	RAINBOW_COLORS[1],
+	RAINBOW_COLORS[9],
+]
+
 export const fruit = [
   "🍈",
   "🥭",

--- a/scripts/data/levels/+ fractions lv1.js
+++ b/scripts/data/levels/+ fractions lv1.js
@@ -1,7 +1,8 @@
 // + fractions lv1
 import rand from "../../helpers/rand.js";
 
-import { RAINBOW_COLORS } from "../constants.js";
+import { SCATTERED_COLORS } from "../constants.js";
+
 
 import {
   makeCircle,
@@ -68,7 +69,7 @@ const level = {
     for (let sliceNumber = 1; sliceNumber <= answer; sliceNumber++) {
       addSlice(
         svg,
-        RAINBOW_COLORS[sliceNumber - 1],
+        SCATTERED_COLORS[sliceNumber - 1],
         answerObject.size,
         270 + anglePerSlice * (sliceNumber - 1)
       );
@@ -91,7 +92,7 @@ const level = {
 		const singleSliceContainer = makeCircle();
 		addSlice(
 			singleSliceContainer,
-			RAINBOW_COLORS[0],
+			SCATTERED_COLORS[0],
 			answerObject.size,
 			270
 		);


### PR DESCRIPTION
Firefox wouldn't accept a calc as a value for a `<circle>`'s "stroke-dasharray" value: had to insert the result instead.

Having the slices of a circle span the rainbow didn't offer much contrast from one slice to the next. Using a new array of colors that bounces around the spectrum.